### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 The server proxies requests from client to JetBrains IDE.
 
+<a href="https://glama.ai/mcp/servers/k7xzbtlxvb"><img width="380" height="200" src="https://glama.ai/mcp/servers/k7xzbtlxvb/badge" alt="mcp-jetbrains MCP server" /></a>
+
 ## Install MCP Server plugin
 
 https://plugins.jetbrains.com/plugin/26071-mcp-server


### PR DESCRIPTION
This PR adds a badge for the mcp-jetbrains server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/k7xzbtlxvb"><img width="380" height="200" src="https://glama.ai/mcp/servers/k7xzbtlxvb/badge" alt="mcp-jetbrains MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.