### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![official JetBrains project](http://jb.gg/badges/incubator-flat-square.svg)](https://github.com/JetBrains#jetbrains-on-github)
+[![smithery badge](https://smithery.ai/badge/@jetbrains/mcp-proxy)](https://smithery.ai/server/@jetbrains/mcp-proxy)
 # JetBrains MCP Proxy Server
 
 The server proxies requests from client to JetBrains IDE.
@@ -34,4 +35,3 @@ If you're running multiple IDEs with MCP server and want to connect to the speci
 1. Tested on macOS
 2. `brew install node pnpm`
 3. Run `pnpm build` to build the project
-


### PR DESCRIPTION
This PR adds a badge to the README to display the number of installations from Smithery, providing visibility on the installation metrics: https://smithery.ai/server/@jetbrains/mcp-proxy

Let me know if any tweaks have to be made!