### PR TITLE
Force IPv4 usage by replacing localhost with 127.0.0.1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ async function testListTools(endpoint: string): Promise<boolean> {
 }
 
 /**
- * Finds and returns a working IDE endpoint by:
+ * Finds and returns a working IDE endpoint using IPv4 by:
  * 1. Checking process.env.IDE_PORT, or
  * 2. Scanning ports 63342-63352
  *
@@ -92,7 +92,7 @@ async function findWorkingIDEEndpoint(): Promise<string> {
     // 1. If user specified a port, just use that
     if (process.env.IDE_PORT) {
         log(`IDE_PORT is set to ${process.env.IDE_PORT}. Testing this port.`);
-        const testEndpoint = `http://localhost:${process.env.IDE_PORT}/api`;
+        const testEndpoint = `http://127.0.0.1:${process.env.IDE_PORT}/api`;
         if (await testListTools(testEndpoint)) {
             log(`IDE_PORT ${process.env.IDE_PORT} is working.`);
             return testEndpoint;
@@ -104,7 +104,7 @@ async function findWorkingIDEEndpoint(): Promise<string> {
 
     // 2. Otherwise, scan a range of ports
     for (let port = 63342; port <= 63352; port++) {
-        const candidateEndpoint = `http://localhost:${port}/api`;
+        const candidateEndpoint = `http://127.0.0.1:${port}/api`;
         log(`Testing port ${port}...`);
         const isWorking = await testListTools(candidateEndpoint);
         if (isWorking) {


### PR DESCRIPTION
## Description
This PR fixes a common issue where the MCP server fails to connect to JetBrains IDEs when using `localhost` which resolves to IPv6 (::1) while the IDE is only listening on IPv4 (127.0.0.1).

## Changes
- Modified `findWorkingIDEEndpoint()` to use `127.0.0.1` instead of `localhost`
- Added explicit IPv4 usage in the endpoint URLs

## Related Issues
- Fixes #4 - "Error: Specified IDE_PORT=63342 but it is not responding correctly"
- Fixes #5 - "No available MCP tools"

## Testing
Tested with:
1. Claude Desktop configured with `github:Farzoo/mcp-jetbrains#feature/force-ipv4`
2. JetBrains IDE (Rider) with MCP Server plugin 1.0.11
3. Both default port (63342) and custom port configurations
4. Successfully fixed the IPv6/IPv4 connection issues

The configuration used for testing:
```json
{
  "mcpServers": {
    "jetbrains-ipv4": {
      "command": "npx",
      "args": [
        "github:Farzoo/mcp-jetbrains#feature/force-ipv4"
      ],
      "env": {
        "LOG_ENABLED": "true",
        "IDE_PORT": "63342"
      }
    }
  }
}
```